### PR TITLE
fix find_package for packages in the source tree, out of the system /…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,8 @@ if(ENABLE_ABIWORD)
 endif(ENABLE_ABIWORD)
 if(LIBOPENJPEG_FOUND)
   include_directories(${LIBOPENJPEG_INCLUDE_DIR})
+  link_directories(${LIBOPENJPEG_LIBRARY_DIR})
+
 endif(LIBOPENJPEG_FOUND)
 if(LCMS_FOUND)
   include_directories(${LCMS_INCLUDE_DIR})


### PR DESCRIPTION
Problem:
When building poppler with openjpeg outside of the system root, poppler's cmake find_package finds openjpeg but does not setup the library link dir and fails to link. ex: -Lmyinstallroot/lib
